### PR TITLE
Update tts_engine.py

### DIFF
--- a/paddlespeech/server/engine/tts/online/onnx/tts_engine.py
+++ b/paddlespeech/server/engine/tts/online/onnx/tts_engine.py
@@ -86,7 +86,7 @@ class TTSServerExecutor(TTSExecutor):
             else:
                 self.am_ckpt = os.path.abspath(am_ckpt[0])
                 self.phones_dict = os.path.abspath(phones_dict)
-                self.am_res_path = os.path.dirname(os.path.abspath(am_ckpt))
+                self.am_res_path = os.path.dirname(os.path.abspath(am_ckpt[0]))
 
             # create am sess
             self.am_sess = get_sess(self.am_ckpt, am_sess_conf)


### PR DESCRIPTION
Fix "TypeError: expected str, bytes or os.PathLike object, not list"

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
os.path.abspath() should take a string(am_ckpt[0]) instead of a list(am_ckpt). See line 122 for reference.